### PR TITLE
Handle nested arrays by returning early, recursing into them

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ module.exports = function mapObj(obj, fn, opts, seen) {
 	const target = opts.target;
 	delete opts.target;
 
+	if (Array.isArray(obj)) {
+		return mapArray(obj);
+	}
+
 	for (const key of Object.keys(obj)) {
 		const val = obj[key];
 		const res = fn(key, val, obj);
@@ -32,7 +36,7 @@ module.exports = function mapObj(obj, fn, opts, seen) {
 
 		if (opts.deep && isObject(newVal)) {
 			if (Array.isArray(newVal)) {
-				newVal = newVal.map(x => isObject(x) ? mapObj(x, fn, opts, seen) : x);
+				newVal = mapArray(newVal);
 			} else {
 				newVal = mapObj(newVal, fn, opts, seen);
 			}
@@ -42,4 +46,8 @@ module.exports = function mapObj(obj, fn, opts, seen) {
 	}
 
 	return target;
+
+	function mapArray(arr) {
+		return arr.map(x => isObject(x) ? mapObj(x, fn, opts, seen) : x);
+	}
 };

--- a/test.js
+++ b/test.js
@@ -21,6 +21,14 @@ test('deep option', t => {
 	t.deepEqual(actual, expected);
 });
 
+test('nested arrays', t => {
+	const obj = {arr: [[0, 1, 2, {a: 3}]]};
+	const expected = {arr: [[0, 1, 2, {a: 6}]]};
+	const fn = (key, val) => [key, typeof val === 'number' ? val * 2 : val];
+	const actual = m(obj, fn, {deep: true});
+	t.deepEqual(actual, expected);
+});
+
 test('handles circular references', t => {
 	const obj = {one: 1, arr: [2]};
 	obj.circular = obj;


### PR DESCRIPTION
Previously `map-obj` would mishandle nested arrays (i.e. `[[0, 1, 2]]`). It treated the inner array as an object and returned `[{0: 0, 1: 1, 2: 2}]` (an array-like object).

This change checks whether the input value is an array, which it will be when recursing through nested arrays.

Originally discovered in https://github.com/bendrucker/snakecase-keys/issues/3

Ran into some lint errors locally, will send a separate PR resolving those