### PR TITLE
Resolve xo linting errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// customized for this use-case
+// Customized for this use-case
 const isObject = x =>
 	typeof x === 'object' &&
 	x !== null &&
@@ -22,7 +22,7 @@ module.exports = function mapObj(obj, fn, opts, seen) {
 
 	seen.set(obj, opts.target);
 
-	const target = opts.target;
+	const {target} = opts;
 	delete opts.target;
 
 	for (const key of Object.keys(obj)) {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 test('main', t => {
 	t.is(m({foo: 'bar'}, key => [key, 'unicorn']).foo, 'unicorn');


### PR DESCRIPTION
Resolves the following errors:

```
  index.js:3:1
  ✖   3:1   Comments should not begin with a lowercase character  capitalized-comments
  ✖  25:8   Use object destructuring.                             prefer-destructuring

  test.js:2:1
  ✖   2:1   Do not reference the index file directly              unicorn/import-index
  ✖   2:15  Useless path segments for "./", should be "."         import/no-useless-path-segments

  4 errors
```