### PR TITLE
Passthrough non-object parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,10 @@ const isObject = x =>
 	!(x instanceof Date);
 
 module.exports = function mapObj(object, fn, options, seen) {
-	if (!isObject(object)) return object;
-	
+	if (!isObject(object)) {
+		return object;
+	}
+
 	options = Object.assign({
 		deep: false,
 		target: {}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const isObject = x =>
 	!(x instanceof Date);
 
 module.exports = function mapObj(object, fn, options, seen) {
+	if (!isObject(object)) return object;
+	
 	options = Object.assign({
 		deep: false,
 		target: {}

--- a/test.js
+++ b/test.js
@@ -45,3 +45,8 @@ test('handles circular references', t => {
 
 	t.deepEqual(actual, expected);
 });
+
+test('handle non objects', t => {
+	t.is(m(1), 1);
+	t.deepEqual(m([1]), [1]);
+});

--- a/test.js
+++ b/test.js
@@ -48,5 +48,13 @@ test('handles circular references', t => {
 
 test('handle non objects', t => {
 	t.is(m(1), 1);
+	t.is(m('foobar'), 'foobar');
 	t.deepEqual(m([1]), [1]);
+	t.is(m(null), null);
+	const r = /test/;
+	t.is(m(r), r);
+	const e = new Error('test');
+	t.is(m(e), e);
+	const d = new Date();
+	t.is(m(d), d);
 });


### PR DESCRIPTION
If this function is called with a non Object parameter, return it right away instead of letting WeakMap fail