### PR TITLE
map-obj deep only for certain keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 declare namespace mapObject {
+	type DeepOptionFunction = (sourceKey: string) => boolean;
+
 	type Mapper<
 		SourceObjectType extends {[key: string]: any},
 		MappedObjectKeyType extends string,
@@ -15,7 +17,7 @@ declare namespace mapObject {
 
 		@default false
 		*/
-		deep?: boolean;
+		deep?: boolean | DeepOptionFunction;
 
 		/**
 		Target object to map properties on to.
@@ -40,6 +42,7 @@ Map object keys and values into a new object.
 @param source - Source object to copy properties from.
 @param mapper - Mapping function.
 
+@param options? - Any options which can be applied to the operation
 @example
 ```
 import mapObject = require('map-obj');
@@ -47,7 +50,7 @@ import mapObject = require('map-obj');
 const newObject = mapObject({foo: 'bar'}, (key, value) => [value, key]);
 //=> {bar: 'foo'}
 ```
-*/
+ */
 declare function mapObject<
 	SourceObjectType extends object,
 	TargetObjectType extends {[key: string]: any},

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare namespace mapObject {
 	}
 
 	interface DeepOptions extends Options {
-		deep: true;
+		deep: true | DeepOptionFunction;
 	}
 
 	interface TargetOptions<TargetObjectType extends {[key: string]: any}> extends Options {

--- a/index.js
+++ b/index.js
@@ -30,10 +30,11 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 		return mapArray(object);
 	}
 
+	const deepOption = (options.deep instanceof Function) ? options.deep : () => options.deep;
 	for (const [key, value] of Object.entries(object)) {
 		let [newKey, newValue] = mapper(key, value, object);
 
-		if (options.deep && isObjectCustom(newValue)) {
+		if (deepOption(key) && isObjectCustom(newValue)) {
 			newValue = Array.isArray(newValue) ?
 				mapArray(newValue) :
 				mapObject(newValue, mapper, options, isSeen);

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,15 @@ Type: `object`
 
 ##### deep
 
-Type: `boolean`<br>
+Type: `boolean|Function`<br>
 Default: `false`
 
 Recurse nested objects and objects in arrays.
+
+If using a boolean value it applies to all keys in all nested objects. If using a function
+
+- It has signature `deep(key)`.
+- It must return a single boolean value: `true|false` if the nested object should be mapped
 
 ##### target
 

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ test('deep option', t => {
 		]
 	};
 
-	const expected = {
+	const expectedDeepTrue = {
 		one: 2,
 		object: {
 			two: 4,
@@ -42,9 +42,41 @@ test('deep option', t => {
 		]
 	};
 
+	const expectedDeepFalse = {
+		one: 2,
+		object: {
+			two: 2,
+			three: 3
+		},
+		array: [
+			{
+				four: 4
+			},
+			5
+		]
+	};
+
+	const expectedDeepFunction = {
+		one: 2,
+		object: {
+			two: 2,
+			three: 3
+		},
+		array: [
+			{
+				four: 8
+			},
+			5
+		]
+	};
+
 	const mapper = (key, value) => [key, typeof value === 'number' ? value * 2 : value];
-	const actual = mapObject(object, mapper, {deep: true});
-	t.deepEqual(actual, expected);
+	const actualDeepTrue = mapObject(object, mapper, {deep: true});
+	const actualDeepFalse = mapObject(object, mapper, {deep: false});
+	const actualDeepFunction = mapObject(object, mapper, {deep: k => k !== 'object'});
+	t.deepEqual(actualDeepTrue, expectedDeepTrue);
+	t.deepEqual(actualDeepFalse, expectedDeepFalse);
+	t.deepEqual(actualDeepFunction, expectedDeepFunction);
 });
 
 test('nested arrays', t => {


### PR DESCRIPTION
We have an application, which receives a final object on which `map-obj` is executed. We had the case that only certain keys should run the deep mode, while others not. As a short example, we had among others a similiar structure as shown here:

```js
const exampleData = {
  testData1: 'someValue',
  testData2: {
  deep1: 'someDeepValue'
  },
  testData3: {
   deep2: {
     deepTest1: 'furtherDeepValue',
     rawData: 'do not perform map-obj on me!'
   },
  }
};
```

Where we wanted several operations via `map-obj` to be executed on the object above, but not on the key "exampleData.testData3.deep2.rawData". Splitting up the object and rejoining it later was quiet inconvenient, since the structure changed from object to object and map-obj was nested in other operations. Howevet, we still know the key which is affected.

Therefore we suggest to extend the deep-option to not handle boolean values only, but also handle a filter method which takes the key and returns a boolean if the deep operation should be executed for this key or not. In this particular case it could be:

```js
{ deep: (key) => key !== 'rawData' }
```

Appreciate your feedback. Cheers!