### PR TITLE
Add new stopRecursion option (Suggested in #23)

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,18 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 	}
 
 	for (const [key, value] of Object.entries(object)) {
-		let [newKey, newValue] = mapper(key, value, object);
+		let [newKey, newValue, mapperOptions = {shouldRecurse: true}] = mapper(key, value, object);
 
-		if (options.deep && isObjectCustom(newValue)) {
+		if (typeof mapperOptions.shouldRecurse !== 'boolean') {
+			throw new TypeError(`Expected mapperOptions.shouldRecurse to be a boolean, got \`${mapperOptions.shouldRecurse}\` (${typeof mapperOptions.shouldRecurse})`);
+		}
+
+		const shouldRecurse =
+			options.deep &&
+			mapperOptions.shouldRecurse === true &&
+			isObjectCustom(newValue);
+
+		if (shouldRecurse) {
 			newValue = Array.isArray(newValue) ?
 				mapArray(newValue) :
 				mapObject(newValue, mapper, options, isSeen);

--- a/readme.md
+++ b/readme.md
@@ -32,12 +32,19 @@ Source object to copy properties from.
 
 #### mapper
 
-Type: `Function`
+Type: `Function`<br>
+Signature: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?]`
 
-Mapping function.
+##### mapperOptions
 
-- It has signature `mapper(sourceKey, sourceValue, source)`.
-- It must return a two item array: `[targetKey, targetValue]`.
+Type: `object`<br>
+Default: `{shouldRecurse: true}`
+
+######  shouldRecurse
+
+Type: `boolean`<br>
+
+Stop recursing down the tree if `false`.
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,7 @@ Source object to copy properties from.
 
 #### mapper
 
-Type: `Function`<br>
-Signature: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?]`
+Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?]`
 
 ##### mapperOptions
 

--- a/test.js
+++ b/test.js
@@ -111,3 +111,44 @@ test('validates input', t => {
 		mapObject(1, () => {});
 	}, TypeError);
 });
+
+test('deep option with shouldRecurse=false', t => {
+	const object = {
+		one: 1,
+		object: {
+			two: 2,
+			three: 3
+		},
+		array: [
+			{
+				four: 4
+			},
+			5
+		]
+	};
+
+	const expected = {
+		one: 2,
+		object: {
+			two: 2,
+			three: 3
+		},
+		array: [
+			{
+				four: 8
+			},
+			5
+		]
+	};
+
+	const mapper = (key, value) => {
+		if (key === 'object') {
+			return [key, value, {shouldRecurse: false}];
+		}
+
+		return [key, typeof value === 'number' ? value * 2 : value];
+	};
+
+	const actual = mapObject(object, mapper, {deep: true});
+	t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
This is a stab at implementing https://github.com/sindresorhus/map-obj/issues/23

(Use case is for an issue described in https://github.com/gajus/format-graphql/issues/10)

Super quick tl;dr of the new proposed API I've implemented:

```js
mapObject(schema, (key, value, _, stopRecursion) => {
  let goDeeper = null;

  if (key === 'MAGIC_VALUE') {
    goDeeper = stopRecursion;
  }

  return [
    key,
    value,
    goDeeper,
  ];
}, {
  deep: true,
});
```

(`stopRecursion` is a Symbol, as suggested)

This is in an effort to avoid a breaking change.

### Possible Alternative API

The above is just one way of doing this - super open to any other suggested APIs for this. Here's a few other directions I considered:

#### Provide the `stopRecursion` symbol as a top level export

It doesn't need to be a argument provided to the callback, we might want to provide something like:

```js
import mapObject, { stopRecursion } from 'map-obj';
```

#### Passing an object as the third item in the tuple

This would allow for future additions to the callback return without forcing users into an awkward `[key, value, _, __, ___, someNewParam]` situation:

```js
return [key, value, { stopRecursion }];
```

#### Alternative naming for `stopRecursion`

Here's some I considered:

- endRecursion
- stopRecurse
- haltDescent
- dontDescend
- whoahThere

Thanks!

cc @gajus