### PR TITLE
Test with `__proto__` keys

### DIFF
--- a/test.js
+++ b/test.js
@@ -152,3 +152,15 @@ test('validates input', t => {
 		mapObject(1, () => {});
 	}, TypeError);
 });
+
+test.failing('identity function preserves __proto__ keys', t => {
+	const input = {['__proto__']: {one: 1}};
+	t.deepEqual(mapObject(input, (key, value) => [key, value]), input);
+});
+
+test.failing('mapper can produce __proto__ keys', t => {
+	t.deepEqual(
+		mapObject({proto: {one: 1}}, (key, value) => [`__${key}__`, value]),
+		{['__proto__']: {one: 1}}
+	);
+});


### PR DESCRIPTION
Adds two failing test cases for #33: mapping `__proto__` keys through the identity function, and outputting new `__proto__` keys from a mapper function.