### PR TITLE
Drop `__proto__` keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 	for (const [key, value] of Object.entries(object)) {
 		let [newKey, newValue, {shouldRecurse = true} = {}] = mapper(key, value, object);
 
-		// Drop __proto__ keys; see issue #33
+		// Drop `__proto__` keys.
 		if (newKey === '__proto__') {
 			continue;
 		}

--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 	for (const [key, value] of Object.entries(object)) {
 		let [newKey, newValue, {shouldRecurse = true} = {}] = mapper(key, value, object);
 
+		// Drop __proto__ keys; see issue #33
+		if (newKey === '__proto__') {
+			continue;
+		}
+
 		if (options.deep && shouldRecurse && isObjectCustom(newValue)) {
 			newValue = Array.isArray(newValue) ?
 				mapArray(newValue) :

--- a/test.js
+++ b/test.js
@@ -164,3 +164,13 @@ test.failing('mapper can produce __proto__ keys', t => {
 		{['__proto__']: {one: 1}}
 	);
 });
+
+test.failing('__proto__ keys are safely dropped', t => {
+	const input = {['__proto__']: {one: 1}};
+	const output = mapObject(input, (key, value) => [key, value]);
+	t.deepEqual(output, {});
+	// AVA's equality checking isn't quite strict enough to catch the difference
+	// between plain objects as prototypes and Object.prototype, so we also check
+	// the prototype by identity
+	t.is(Object.getPrototypeOf(output), Object.prototype);
+});

--- a/test.js
+++ b/test.js
@@ -153,18 +153,6 @@ test('validates input', t => {
 	}, TypeError);
 });
 
-test.failing('identity function preserves __proto__ keys', t => {
-	const input = {['__proto__']: {one: 1}};
-	t.deepEqual(mapObject(input, (key, value) => [key, value]), input);
-});
-
-test.failing('mapper can produce __proto__ keys', t => {
-	t.deepEqual(
-		mapObject({proto: {one: 1}}, (key, value) => [`__${key}__`, value]),
-		{['__proto__']: {one: 1}}
-	);
-});
-
 test('__proto__ keys are safely dropped', t => {
 	const input = {['__proto__']: {one: 1}};
 	const output = mapObject(input, (key, value) => [key, value]);

--- a/test.js
+++ b/test.js
@@ -157,6 +157,7 @@ test('__proto__ keys are safely dropped', t => {
 	const input = {['__proto__']: {one: 1}};
 	const output = mapObject(input, (key, value) => [key, value]);
 	t.deepEqual(output, {});
+
 	// AVA's equality checking isn't quite strict enough to catch the difference
 	// between plain objects as prototypes and Object.prototype, so we also check
 	// the prototype by identity

--- a/test.js
+++ b/test.js
@@ -165,7 +165,7 @@ test.failing('mapper can produce __proto__ keys', t => {
 	);
 });
 
-test.failing('__proto__ keys are safely dropped', t => {
+test('__proto__ keys are safely dropped', t => {
 	const input = {['__proto__']: {one: 1}};
 	const output = mapObject(input, (key, value) => [key, value]);
 	t.deepEqual(output, {});


### PR DESCRIPTION
Fixes #33 by dropping `'__proto__'` keys output by the mapper.

This shouldn't be a breaking change. It only affects behavior in cases that were previously buggy.

It's simple enough to instead throw errors on `'__proto__'` keys if that's what's desired.