### PR TITLE
Add `mapObject.mapObjectSkip` for removing object keys

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace mapObject {
 		targetKey: MappedObjectKeyType,
 		targetValue: MappedObjectValueType,
 		mapperOptions?: mapObject.MapperOptions
-	] | mapObject.mapObjSkip;
+	] | mapObject.mapObjectSkip;
 
 	interface Options {
 		/**
@@ -46,7 +46,7 @@ declare namespace mapObject {
 		shouldRecurse?: boolean;
 	}
 
-	export type mapObjSkip = symbol
+	export type mapObjectSkip = symbol
 }
 
 /**
@@ -68,7 +68,7 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.toLowerCase(), value], {deep: true});
 //=> {foo: true, bar: {baz: true}}
 
-const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip);
+const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjectSkip);
 //=> {one: 1}
 ```
 */

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace mapObject {
 		targetKey: MappedObjectKeyType,
 		targetValue: MappedObjectValueType,
 		mapperOptions?: mapObject.MapperOptions
-	];
+	] | mapObject.mapObjSkip;
 
 	interface Options {
 		/**
@@ -45,6 +45,8 @@ declare namespace mapObject {
 		*/
 		shouldRecurse?: boolean;
 	}
+
+	export type mapObjSkip = symbol
 }
 
 /**
@@ -65,6 +67,9 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.toLowerCase(), value], {deep: true});
 //=> {foo: true, bar: {baz: true}}
+
+const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip);
+//=> {one: 1}
 ```
 */
 declare function mapObject<

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,6 @@ declare namespace mapObject {
 		shouldRecurse?: boolean;
 	}
 
-
 	/**
 	Return this value from a `mapper` function to remove a key from an object.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ declare namespace mapObject {
 		targetKey: MappedObjectKeyType,
 		targetValue: MappedObjectValueType,
 		mapperOptions?: mapObject.MapperOptions
-	] | mapObject.mapObjectSkip;
+	] | typeof mapObject.mapObjectSkip;
 
 	interface Options {
 		/**
@@ -46,8 +46,27 @@ declare namespace mapObject {
 		shouldRecurse?: boolean;
 	}
 
-	export type mapObjectSkip = symbol
+
+	/**
+	Return this value from a `mapper` function to remove a key from an object.
+
+	```js
+	const mapObject = require('map-obj');
+
+	const object = {one: 1, two: 2}
+	const mapper = (key, value) => value === 1 ? [key, value] : mapObject.mapObjectSkip
+	const result = mapObject(object, mapper);
+
+	console.log(result);
+	//=> {one: 1}
+	```
+	*/
+	const mapObjectSkip: typeof UniqueSymbol
 }
+
+// unique symbol cannot be declared in a namespace directly, so we declare it top-level
+// See: https://github.com/sindresorhus/map-obj/pull/38#discussion_r702396878
+declare const UniqueSymbol: unique symbol;
 
 /**
 Map object keys and values into a new object.

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,12 +60,12 @@ declare namespace mapObject {
 	//=> {one: 1}
 	```
 	*/
-	const mapObjectSkip: typeof UniqueSymbol
+	const mapObjectSkip: typeof uniqueSymbol
 }
 
 // unique symbol cannot be declared in a namespace directly, so we declare it top-level
 // See: https://github.com/sindresorhus/map-obj/pull/38#discussion_r702396878
-declare const UniqueSymbol: unique symbol;
+declare const uniqueSymbol: unique symbol;
 
 /**
 Map object keys and values into a new object.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const isObject = value => typeof value === 'object' && value !== null;
+const mapObjSkip = Symbol('skip');
 
 // Customized for this use-case
 const isObjectCustom = value =>
@@ -31,7 +32,13 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 	}
 
 	for (const [key, value] of Object.entries(object)) {
-		let [newKey, newValue, {shouldRecurse = true} = {}] = mapper(key, value, object);
+		const mapResult = mapper(key, value, object);
+
+		if (mapResult === mapObjSkip) {
+			continue;
+		}
+
+		let [newKey, newValue, {shouldRecurse = true} = {}] = mapResult;
 
 		// Drop `__proto__` keys.
 		if (newKey === '__proto__') {
@@ -57,3 +64,5 @@ module.exports = (object, mapper, options) => {
 
 	return mapObject(object, mapper, options);
 };
+
+module.exports.mapObjSkip = mapObjSkip;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const isObject = value => typeof value === 'object' && value !== null;
-const mapObjSkip = Symbol('skip');
+const mapObjectSkip = Symbol('skip');
 
 // Customized for this use-case
 const isObjectCustom = value =>
@@ -34,7 +34,7 @@ const mapObject = (object, mapper, options, isSeen = new WeakMap()) => {
 	for (const [key, value] of Object.entries(object)) {
 		const mapResult = mapper(key, value, object);
 
-		if (mapResult === mapObjSkip) {
+		if (mapResult === mapObjectSkip) {
 			continue;
 		}
 
@@ -65,4 +65,4 @@ module.exports = (object, mapper, options) => {
 	return mapObject(object, mapper, options);
 };
 
-module.exports.mapObjSkip = mapObjSkip;
+module.exports.mapObjectSkip = mapObjectSkip;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -34,3 +34,5 @@ expectAssignable<{[key: string]: unknown}>(object3);
 expectType<'baz'>(object3.bar);
 
 mapObject({foo: 'bar'}, (key, value) => [value, key, {shouldRecurse: false}]);
+
+mapObject({foo: 'bar'}, () => mapObject.mapObjSkip);

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -35,4 +35,4 @@ expectType<'baz'>(object3.bar);
 
 mapObject({foo: 'bar'}, (key, value) => [value, key, {shouldRecurse: false}]);
 
-mapObject({foo: 'bar'}, () => mapObject.mapObjSkip);
+mapObject({foo: 'bar'}, () => mapObject.mapObjectSkip);

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Target object to map properties on to.
 
 ### mapObject.mapObjectSkip
 
-Return this value from a `mapper` function to remove a key from an object.
+Return this value from a `mapper` function to exclude the key from the new object.
 
 ```js
 const mapObject = require('map-obj');

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.toLowerCase(), value], {deep: true});
 //=> {foo: true, bar: {baz: true}}
 
-const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip);
+const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjectSkip);
 //=> {one: 1}
 ```
 
@@ -38,7 +38,7 @@ Source object to copy properties from.
 
 #### mapper
 
-Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?] | mapObject.mapObjSkip`
+Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?] | mapObject.mapObjectSkip`
 
 Mapping function.
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.toLowerCase(), value], {deep: true});
 //=> {foo: true, bar: {baz: true}}
+
+const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip);
+//=> {one: 1}
 ```
 
 ## API
@@ -35,7 +38,7 @@ Source object to copy properties from.
 
 #### mapper
 
-Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?]`
+Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?] | mapObject.mapObjSkip`
 
 Mapping function.
 

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,21 @@ Default: `{}`
 
 Target object to map properties on to.
 
+### mapObject.mapObjectSkip
+
+Return this value from a `mapper` function remove a key from an object.
+
+```js
+const mapObject = require('map-obj');
+
+const object = {one: 1, two: 2}
+const mapper = (key, value) => value === 1 ? [key, value] : mapObject.mapObjectSkip
+const result = mapObject(object, mapper);
+
+console.log(result);
+//=> {one: 1}
+```
+
 ## Related
 
 - [filter-obj](https://github.com/sindresorhus/filter-obj) - Filter object keys and values into a new object

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Target object to map properties on to.
 
 ### mapObject.mapObjectSkip
 
-Return this value from a `mapper` function remove a key from an object.
+Return this value from a `mapper` function to remove a key from an object.
 
 ```js
 const mapObject = require('map-obj');

--- a/test.js
+++ b/test.js
@@ -174,7 +174,7 @@ test('remove keys (#36)', t => {
 		one: 1
 	};
 
-	const mapper = (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip;
+	const mapper = (key, value) => value === 1 ? [key, value] : mapObject.mapObjectSkip;
 	const actual = mapObject(object, mapper, {deep: true});
 	t.deepEqual(actual, expected);
 });

--- a/test.js
+++ b/test.js
@@ -163,3 +163,18 @@ test('__proto__ keys are safely dropped', t => {
 	// the prototype by identity
 	t.is(Object.getPrototypeOf(output), Object.prototype);
 });
+
+test('remove keys (#36)', t => {
+	const object = {
+		one: 1,
+		two: 2
+	};
+
+	const expected = {
+		one: 1
+	};
+
+	const mapper = (key, value) => value === 1 ? [key, value] : mapObject.mapObjSkip;
+	const actual = mapObject(object, mapper, {deep: true});
+	t.deepEqual(actual, expected);
+});


### PR DESCRIPTION
closes #36

I need help with the types please. The setup is different from https://github.com/sindresorhus/p-map/blob/main/index.d.ts, and I wasn't able to figure out how to define the types for the `mapObject.mapObjSkip` symbol