### PR TITLE
Add 'path' parameter to the mapper function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,8 @@ export type Mapper<
 > = (
 	sourceKey: keyof SourceObjectType,
 	sourceValue: SourceObjectType[keyof SourceObjectType],
-	source: SourceObjectType
+	source: SourceObjectType,
+	path: string[],
 ) => [
 	targetKey: MappedObjectKeyType,
 	targetValue: MappedObjectValueType,

--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ const _mapObject = (object, mapper, options, {isSeen = new WeakMap(), path = []}
 	const {target} = options;
 	delete options.target;
 
-	const mapArray = array => array.map((element, i) =>
+	const mapArray = array => array.map((element, index) =>
 		isObjectCustom(element)
-			? _mapObject(element, mapper, options, {isSeen, path: [...path, i]})
+			? _mapObject(element, mapper, options, {isSeen, path: [...path, index]})
 			: element,
 	);
 

--- a/index.js
+++ b/index.js
@@ -25,14 +25,14 @@ const _mapObject = (object, mapper, options, {isSeen = new WeakMap(), path = []}
 	const {target} = options;
 	delete options.target;
 
-	const mapArray = array => array.map((element, index) =>
+	const mapArray = (array, arrayPath) => array.map((element, index) =>
 		isObjectCustom(element)
-			? _mapObject(element, mapper, options, {isSeen, path: [...path, index]})
+			? _mapObject(element, mapper, options, {isSeen, path: [...arrayPath, index]})
 			: element,
 	);
 
 	if (Array.isArray(object)) {
-		return mapArray(object);
+		return mapArray(object, path);
 	}
 
 	for (const [key, value] of Object.entries(object)) {
@@ -51,7 +51,7 @@ const _mapObject = (object, mapper, options, {isSeen = new WeakMap(), path = []}
 
 		if (options.deep && shouldRecurse && isObjectCustom(newValue)) {
 			newValue = Array.isArray(newValue)
-				? mapArray(newValue)
+				? mapArray(newValue, [...path, key])
 				: _mapObject(newValue, mapper, options, {isSeen, path: [...path, key]});
 		}
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const _mapObject = (object, mapper, options, {isSeen = new WeakMap(), path = []}
 	}
 
 	for (const [key, value] of Object.entries(object)) {
-		const mapResult = mapper(key, value, object, options.deep ? [...path, key] : undefined);
+		const mapResult = mapper(key, value, object, options.deep ? [...path, key] : []);
 
 		if (mapResult === mapObjectSkip) {
 			continue;

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,19 @@ Type: `string[]`\
 If `deep === true`, this is the sequence of keys to reach the current value from the `source`;
 otherwise it is an empty array.
 
+For arrays, the key is the index of the element being mapped.
+
+Example:
+```js
+const originalObject = {first: [{value: 1}, {value: 2}, {value: 3}], second: [{value: 4}, {value: 5}, {value: 6}]};
+const mapper = (key, value, source, path) => path.includes('first') || path.includes(1)
+	? [`__${key}__`, value]
+	: [key, value];
+
+const newObject = mapObject(originalObject, mapper, {deep: true});
+//=> {__first__: [{__value__: 1}, {__value__: 2}, {__value__: 3}], second: [{value: 4}, {__value__: 5}, {value: 6}]}
+```
+
 ##### mapperOptions
 
 Type: `object`

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ A mapping function.
 
 ##### path
 
-Type: `string[]|undefined`\
+Type: `string[] | undefined`\
 
 If `deep === true`, this is the sequence of keys to reach the current value from the `source`;
 otherwise it is `undefined`.

--- a/readme.md
+++ b/readme.md
@@ -44,16 +44,19 @@ A mapping function.
 
 ##### path
 
-Type: `string[]`\
+Type: `string[]`
 
-If `deep === true`, this is the sequence of keys to reach the current value from the `source`;
-otherwise it is an empty array.
+When using `{deep: true}`, this is the sequence of keys to reach the current value from the `source`, otherwise it is an empty array.
 
 For arrays, the key is the index of the element being mapped.
 
 Example:
+
 ```js
+import mapObject from 'map-obj';
+
 const originalObject = {first: [{value: 1}, {value: 2}, {value: 3}], second: [{value: 4}, {value: 5}, {value: 6}]};
+
 const mapper = (key, value, source, path) => path.includes('first') || path.includes(1)
 	? [`__${key}__`, value]
 	: [key, value];

--- a/readme.md
+++ b/readme.md
@@ -44,10 +44,10 @@ A mapping function.
 
 ##### path
 
-Type: `string[] | undefined`\
+Type: `string[]`\
 
 If `deep === true`, this is the sequence of keys to reach the current value from the `source`;
-otherwise it is `undefined`.
+otherwise it is an empty array.
 
 ##### mapperOptions
 

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,16 @@ The source object to copy properties from.
 
 #### mapper
 
-Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?] | mapObjectSkip`
+Type: `(sourceKey, sourceValue, source, path) => [targetKey, targetValue, mapperOptions?] | mapObjectSkip`
 
 A mapping function.
+
+##### path
+
+Type: `string[]|undefined`\
+
+If `deep === true`, this is the sequence of keys to reach the current value from the `source`;
+otherwise it is `undefined`.
 
 ##### mapperOptions
 

--- a/test.js
+++ b/test.js
@@ -203,7 +203,7 @@ test('mapper argument `path` is only available for deep mappings', t => {
 	mapObject(
 		subject,
 		(key, value, source, path) => {
-			t.is(path, undefined);
+			t.true(Array.isArray(path) && path.length === 0);
 			return [key, value];
 		},
 	);

--- a/test.js
+++ b/test.js
@@ -226,8 +226,11 @@ test('mapper argument `path` contains the sequence of keys to reach the current 
 			deep: {
 				three: 3,
 			},
-
-			array: [4, 5, 6],
+			simpleArray: [4, 5, 6],
+			complexArray: [
+				{seven: 7},
+				{eight: 8},
+			],
 		},
 	};
 
@@ -237,10 +240,10 @@ test('mapper argument `path` contains the sequence of keys to reach the current 
 		'nested.two': 2,
 		'nested.deep': subject.nested.deep,
 		'nested.deep.three': 3,
-		'nested.array': subject.nested.array,
-		'nested.array.0': 4,
-		'nested.array.1': 5,
-		'nested.array.2': 6,
+		'nested.simpleArray': subject.nested.simpleArray,
+		'nested.complexArray': subject.nested.complexArray,
+		'nested.complexArray.0.seven': 7,
+		'nested.complexArray.1.eight': 8,
 	};
 
 	const mapper = (key, value, source, path) => {


### PR DESCRIPTION
Adding a `path` parameter to the mapper function, which contains the list of keys to reach the current value from the source object. This is useful when `deep: true` to know where you are in the map process. The `path` parameter is `undefined` if `deep` option is `false` (the default).