### PR TITLE
Excluded blob and file objects from user object list

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { Blob } from 'node:buffer';
+import {Blob} from 'node:buffer';
 
 const isObject = value => typeof value === 'object' && value !== null;
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const isObjectCustom = value =>
 	isObject(value)
 	&& !(value instanceof RegExp)
 	&& !(value instanceof Error)
-	&& !(value instanceof Date);
+	&& !(value instanceof Date)
+	&& !(value instanceof Blob);
 
 export const mapObjectSkip = Symbol('mapObjectSkip');
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { Blob } from 'node:buffer';
+
 const isObject = value => typeof value === 'object' && value !== null;
 
 // Customized for this use-case


### PR DESCRIPTION
I added a check on Blob instance in function which checks objects custom they or nor. This check will prevent a bug when you have file like object or blob instance within passed object in `mapObject` function and this objects won't be broken because they will be excluded from passing through if deep is true.