### PR TITLE
Add 'path' parameter to the mapper function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,8 @@ export type Mapper<
 > = (
 	sourceKey: keyof SourceObjectType,
 	sourceValue: SourceObjectType[keyof SourceObjectType],
-	source: SourceObjectType
+	source: SourceObjectType,
+	path: string[],
 ) => [
 	targetKey: MappedObjectKeyType,
 	targetValue: MappedObjectValueType,
@@ -85,6 +86,9 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObjectSkip);
 //=> {one: 1}
+
+const newObject = mapObject({foo: {bar: [2], baz: [1, 2, 3]}}, (key, value, source, path) => path.join('.') === 'foo.baz' ? [key, 3] : [key, value], {deep: true});
+//=> {foo: {bar:[2], baz: [3, 3, 3]}}
 ```
 */
 export default function mapObject<

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,6 +23,18 @@ export type Mapper<
 	sourceKey: keyof SourceObjectType,
 	sourceValue: SourceObjectType[keyof SourceObjectType],
 	source: SourceObjectType,
+	/**
+	When using `deep: true`, this is the sequence of keys to reach the current value from the `source`, otherwise it is an empty array.
+	For arrays, the key is the index of the element being mapped.
+	@example
+	import mapObject from 'map-obj';
+	const object = {foo: {bar: [2], baz: [1, 2, 3]}}
+	const mapper = (key, value, source, path) => path.join(".") === "foo.baz" ? [key, 3] : [key, value];
+	const result = mapObject(object, mapper, {deep: true});
+
+	console.log(result);
+	//=> {foo: {bar:[2], baz: [3, 3, 3]}}
+	 */
 	path: string[],
 ) => [
 	targetKey: MappedObjectKeyType,
@@ -86,9 +98,6 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObjectSkip);
 //=> {one: 1}
-
-const newObject = mapObject({foo: {bar: [2], baz: [1, 2, 3]}}, (key, value, source, path) => path.join('.') === 'foo.baz' ? [key, 3] : [key, value], {deep: true});
-//=> {foo: {bar:[2], baz: [3, 3, 3]}}
 ```
 */
 export default function mapObject<

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObjectSkip);
 //=> {one: 1}
+
+const newObject = mapObject({foo: {bar: [2], baz: [1, 2, 3]}}, (key, value, source, path) => path.join('.') === 'foo.baz' ? [key, 3] : [key, value], {deep: true});
+//=> {foo: {bar:[2], baz: [3, 3, 3]}}
 ```
 
 ## API
@@ -38,9 +41,28 @@ The source object to copy properties from.
 
 #### mapper
 
-Type: `(sourceKey, sourceValue, source) => [targetKey, targetValue, mapperOptions?] | mapObjectSkip`
+Type: `(sourceKey, sourceValue, source, path) => [targetKey, targetValue, mapperOptions?] | mapObjectSkip`
 
 A mapping function.
+
+##### path
+
+Type: `string[]`
+
+When using `deep: true`, this is the sequence of keys to reach the current value from the `source`, otherwise it is an empty array.
+
+For arrays, the key is the index of the element being mapped.
+
+```js
+import mapObject from "map-obj";
+
+const object = {foo: {bar: [2], baz: [1, 2, 3]}}
+const mapper = (key, value, source, path) => path.join(".") === "foo.baz" ? [key, 3] : [key, value];
+const result = mapObject(object, 	mapper, { deep: true });
+
+console.log(result);
+//=> {foo: {bar:[2], baz: [3, 3, 3]}}
+```
 
 ##### mapperOptions
 

--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ import mapObject from "map-obj";
 
 const object = {foo: {bar: [2], baz: [1, 2, 3]}}
 const mapper = (key, value, source, path) => path.join(".") === "foo.baz" ? [key, 3] : [key, value];
-const result = mapObject(object, 	mapper, { deep: true });
+const result = mapObject(object, mapper, {deep: true});
 
 console.log(result);
 //=> {foo: {bar:[2], baz: [3, 3, 3]}}

--- a/readme.md
+++ b/readme.md
@@ -24,9 +24,6 @@ const newObject = mapObject({FOO: true, bAr: {bAz: true}}, (key, value) => [key.
 
 const newObject = mapObject({one: 1, two: 2}, (key, value) => value === 1 ? [key, value] : mapObjectSkip);
 //=> {one: 1}
-
-const newObject = mapObject({foo: {bar: [2], baz: [1, 2, 3]}}, (key, value, source, path) => path.join('.') === 'foo.baz' ? [key, 3] : [key, value], {deep: true});
-//=> {foo: {bar:[2], baz: [3, 3, 3]}}
 ```
 
 ## API
@@ -54,7 +51,7 @@ When using `deep: true`, this is the sequence of keys to reach the current value
 For arrays, the key is the index of the element being mapped.
 
 ```js
-import mapObject from "map-obj";
+import mapObject from 'map-obj';
 
 const object = {foo: {bar: [2], baz: [1, 2, 3]}}
 const mapper = (key, value, source, path) => path.join(".") === "foo.baz" ? [key, 3] : [key, value];

--- a/test.js
+++ b/test.js
@@ -189,6 +189,7 @@ test('remove keys (#36)', t => {
 
 test('mapper `path` argument', t => {
 	t.plan(10);
+
 	const subject = {
 		one: 1,
 		nested: {

--- a/test.js
+++ b/test.js
@@ -188,6 +188,7 @@ test('remove keys (#36)', t => {
 });
 
 test('mapper `path` argument', t => {
+	t.plan(10);
 	const subject = {
 		one: 1,
 		nested: {
@@ -203,7 +204,8 @@ test('mapper `path` argument', t => {
 	mapObject(
 		subject,
 		(key, value, source, path) => {
-			t.true(Array.isArray(path) && path.length === 0);
+			t.true(Array.isArray(path));
+			t.is(path.length, 0);
 			return [key, value];
 		},
 	);


### PR DESCRIPTION
Hi @sindresorhus ,

I'm completing the abandoned PR : https://github.com/sindresorhus/map-obj/pull/43  , thank you @leonardoraele for doing most of the work.


> Adding a path parameter to the mapper function, which contains the list of keys to reach the current value from the source object. This is useful when deep: true to know where you are in the map process. The path parameter is ~undefined~ an empty array if deep option is false (the default).


I'd love to have the `path` available in the mapper, too. I've hopefully address your comments in the original PR, I'll outline them in this PR.


